### PR TITLE
Update official guide URL

### DIFF
--- a/upgrade_guides/agoric/upgrade_agoric-upgrade-8.md
+++ b/upgrade_guides/agoric/upgrade_agoric-upgrade-8.md
@@ -4,7 +4,7 @@ The Upgrade is scheduled for block `7179262`. A countdown clock is [here](https:
 
 This guide assumes that you use cosmovisor to manage upgrades
 
-This upgrade is a major upgrade with some agoric Javascript VM specific procedures. Please follow the [official guide](https://github.com/Agoric/agoric-sdk/wiki/ag0-to-agd-upgrade). You wil install NodeJS, Yarn and the agd binary.
+This upgrade is a major upgrade with some agoric Javascript VM specific procedures. Please follow the [official guide](https://github.com/Agoric/agoric-sdk/wiki/ag0-to-agd-upgrade-for-mainnet-1-launch). You wil install NodeJS, Yarn and the agd binary.
 
 If you have issue installing NodeJS with the official guide because you are on a non-LTS version of Linux and you get an error to the effect of "no longer has a Release file", you can still install it through node version manager. See [here](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-20-04).
 


### PR DESCRIPTION
When I updated the Agoric guide, I accidentally oopsed and changed the URL to https://github.com/Agoric/agoric-sdk/wiki/ag0-to-agd-upgrade-for-mainnet-1-launch.